### PR TITLE
Fix related to Android 13 (API level 33) permissions

### DIFF
--- a/android/src/main/java/com/loonix/another_audio_recorder/RequestPermissionHandler.java
+++ b/android/src/main/java/com/loonix/another_audio_recorder/RequestPermissionHandler.java
@@ -44,8 +44,11 @@ public class RequestPermissionHandler implements PluginRegistry.RequestPermissio
     }
 
     private boolean hasRecordPermission(){
-        // if after [Marshmallow], we need to check permission on runtime
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // WRITE_EXTERNAL_STORAGE permission after API level 33 causes error:
+            return (ContextCompat.checkSelfPermission(activity, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            // if after [Marshmallow], we need to check permission on runtime:
             return (ContextCompat.checkSelfPermission(activity, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED)
                     && (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED);
         } else {
@@ -67,7 +70,9 @@ public class RequestPermissionHandler implements PluginRegistry.RequestPermissio
         } else {
             Log.d(TAG, "handleHasPermission false");
 
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+				ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.RECORD_AUDIO}, PERMISSIONS_REQUEST_RECORD_AUDIO);
+			} else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
                 ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.RECORD_AUDIO, Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSIONS_REQUEST_RECORD_AUDIO);
             } else {
                 ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.RECORD_AUDIO}, PERMISSIONS_REQUEST_RECORD_AUDIO);


### PR DESCRIPTION
The package raised permission error on Android 13 devices. This was caused by deprecation of `WRITE_EXTERNAL_STORAGE ` permission. This PR contains a fix for this issue. Aforementioned permission won't be asked on API 33+ devices anymore.